### PR TITLE
Require.JS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Features
 Known Limitations
 -----------------
 
-Backbone Developer Tools require *window.Backbone* to be available on DOMContentLoaded (<strong>no require.js support</strong>, sorry).
+By default, Backbone Developer Tools require *window.Backbone* to be available on DOMContentLoaded. We have a Require.JS fallback method (requires unmodified Backbone >= v0.9.2-120 mapped to the module name "backbone"), but that probably won't work if you're using some other javascript loader.
 
-You could try modifying *js/inject/logger.js* and *js/inject/backbone.debug.js* and including them by yourself.
+If neither the default nor the fallback succeed in injecting Backbone Developer Tools, you can modify *js/inject/attach.js* to meet your specific requirements.
+
+You could also try modifying *js/inject/logger.js* and *js/inject/backbone.debug.js* and including them by yourself.
 Note that unless you alter the extension itself, you'll need to expose the logger at *window.Backbone.debug.logger*.
 
 

--- a/js/inject/attach.js
+++ b/js/inject/attach.js
@@ -22,7 +22,18 @@
 
   var inject = function() {
     if (!window.Backbone) {
-      console.error('[Backbone Dev Tools] Couldn\'t find Backbone');
+      if (require) {
+        require(['backbone'], function(backbone){
+          if (!backbone) {
+            console.error('[Backbone Dev Tools] Couldn\'t find Backbone');
+            return;
+          }
+          inject();
+        });
+      }
+      else {
+        console.error('[Backbone Dev Tools] Couldn\'t find Backbone');
+      }
       return;
     }
 

--- a/templates/general.handlebars
+++ b/templates/general.handlebars
@@ -6,7 +6,8 @@
 
 <p>App requirement for BDT to work:</p>
 <ul>
-  <li>window.Backbone available on DOMContentLoaded (no require.js support as of now, sorry)</li>
+  <li>window.Backbone available on DOMContentLoaded, or</li>
+  <li>Require.JS + unmodified Backbone >= v0.9.2-120 (where Backbone is mapped to the module name "backbone")</li>
 </ul>
 
 <h1>Features</h1>


### PR DESCRIPTION
If `window.Backbone` is not found on `DOMContentLoaded` but we detect that `require` is loaded, then we try to load Backbone that way.
