### PR TITLE
Include element classnames in pretty(elem)

### DIFF
--- a/js/page.js
+++ b/js/page.js
@@ -30,7 +30,7 @@
 
       // display elemens as eg. div#todoapp
       function pretty(elem) {
-        return elem.tagName.toLowerCase() + (elem.id && ("#" + elem.id));
+        return elem.tagName.toLowerCase() + (elem.id && ("#" + elem.id)) + (elem.className && ('.' + elem.className.split(/\s+/).join('.')));
       }
 
       // we need to prefix element names if we want to preserve the order


### PR DESCRIPTION
I find it helpful to include classnames because most elements in my code do not have an ID, so all I see is 'div..div...div' :\
